### PR TITLE
Updated version of BlueCryptor dependency to remove CommonCrypto warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "HKDF", targets: ["HKDF"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "0.8.0"),
+        .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from: "1.0.14"),
     ],
     targets: [
         .target(name: "HKDF", dependencies: ["Cryptor"], path: "Sources"),


### PR DESCRIPTION
The reason this update is needed is become BlueCryptor depends on CommonCrypto. CommonCrypto was previously a package that needed to be added as an explicit dependency. It has now become a system library, so adding an explicit dependency causes compilation problems. The updated version of BlueCryptor fixes this problem.